### PR TITLE
Fixed a typo in name menu

### DIFF
--- a/src/entity/name.ts
+++ b/src/entity/name.ts
@@ -9,7 +9,7 @@ export class Name implements FakerEntity {
     return [
       'firstName',
       'lastName',
-      'findName',
+      'fullName',
       'jobTitle',
       'prefix',
       'suffix',

--- a/test/entity/name.test.ts
+++ b/test/entity/name.test.ts
@@ -18,7 +18,7 @@ describe('Name Entity Tests', () => {
     expect(name.getMethods()).to.eql([
       'firstName',
       'lastName',
-      'findName',
+      'fullName',
       'jobTitle',
       'prefix',
       'suffix',


### PR DESCRIPTION
Fixed a typo in the name entity menu to be more descriptive