### PR TITLE
Replace faker lib with @faker-js/faker

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,23 +8,28 @@
 
 // A task runner that calls a custom npm script that compiles the extension.
 {
-	"version": "0.1.0",
+  "version": "2.0.0",
 
-	// we want to run npm
-	"command": "npm",
+  // we want to run npm
+  "command": "npm",
 
-	// the command is a shell script
-	"isShellCommand": true,
+  // we run the custom script "compile" as defined in package.json
+  "args": ["run", "compile", "--loglevel", "silent"],
 
-	// show the output window only if unrecognized errors occur.
-	"showOutput": "silent",
+  // The tsc compiler is started in watching mode
+  "isBackground": true,
 
-	// we run the custom script "compile" as defined in package.json
-	"args": ["run", "compile", "--loglevel", "silent"],
-
-	// The tsc compiler is started in watching mode
-	"isWatching": true,
-
-	// use the standard tsc in watch mode problem matcher to find compile problems in the output.
-	"problemMatcher": "$tsc-watch"
+  // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+  "problemMatcher": "$tsc-watch",
+  "tasks": [
+    {
+      "label": "npm",
+      "type": "shell",
+      "command": "npm",
+      "args": ["run", "compile", "--loglevel", "silent"],
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch",
+      "group": "build"
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@faker-js/faker": {
+      "version": "6.0.0-alpha.6",
+      "resolved": "https://nexus.infrastructure.rapid-sys.com/repository/isv-npm/@faker-js/faker/-/faker-6.0.0-alpha.6.tgz",
+      "integrity": "sha512-+jatKq8wYwOgCpVQ0wE4t9BglS16qJH/Nu4WjPU+ABTywivTY8BCsD1XIZhw9iXDq3t1InyiXmz+R70TcUMbrg=="
+    },
     "@istanbuljs/nyc-config-typescript": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz",
@@ -147,12 +152,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.3.tgz",
       "integrity": "sha512-VRw2xEGbll3ZiTQ4J02/hUjNqZoue1bMhoo2dgM2LXjDdyaq4q80HgBDHwpI0/VKlo4Eg+BavyQMv/NYgTetzA==",
-      "dev": true
-    },
-    "@types/faker": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.1.2.tgz",
-      "integrity": "sha512-a3FADSHjjinczCwr7tTejoMZzbSS5vi70VCyns4C1idxJrDSRGZCQG0s27YppXLcoWrBOkwBbBsZ9vDRDpQK7A==",
       "dev": true
     },
     "@types/json5": {
@@ -855,11 +854,6 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
-    },
-    "faker": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-5.1.0.tgz",
-      "integrity": "sha512-RrWKFSSA/aNLP0g3o2WW1Zez7/MnMr7xkiZmoCfAGZmdkDQZ6l2KtuXHN5XjdvpRjDl8+3vf+Rrtl06Z352+Mw=="
     },
     "fast-deep-equal": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/chai": "^4.2.3",
-    "@types/faker": "^5.1.2",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.7.11",
     "@types/vscode": "^1.32.0",
@@ -200,7 +199,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "faker": "~5.1.0"
+    "@faker-js/faker": "^6.0.0-alpha.6"
   },
   "lint-staged": {
     "*.{ts,json}": [

--- a/src/faker-factory.ts
+++ b/src/faker-factory.ts
@@ -1,94 +1,94 @@
 export function fakerFactory(locale: string) {
   switch (locale) {
     case 'az':
-      return import('faker/locale/az');
+      return import('@faker-js/faker/locale/az');
     case 'ar':
-      return import('faker/locale/ar');
+      return import('@faker-js/faker/locale/ar');
     case 'cz':
-      return import('faker/locale/cz');
+      return import('@faker-js/faker/locale/cz');
     case 'de':
-      return import('faker/locale/de');
+      return import('@faker-js/faker/locale/de');
     case 'de_AT':
-      return import('faker/locale/de_AT');
+      return import('@faker-js/faker/locale/de_AT');
     case 'de_CH':
-      return import('faker/locale/de_CH');
+      return import('@faker-js/faker/locale/de_CH');
     case 'en':
-      return import('faker/locale/en');
+      return import('@faker-js/faker/locale/en');
     case 'en_AU':
-      return import('faker/locale/en_AU');
+      return import('@faker-js/faker/locale/en_AU');
     case 'en_AU_ocker':
-      return import('faker/locale/en_AU_ocker');
+      return import('@faker-js/faker/locale/en_AU_ocker');
     case 'en_BORK':
-      return import('faker/locale/en_BORK');
+      return import('@faker-js/faker/locale/en_BORK');
     case 'en_CA':
-      return import('faker/locale/en_CA');
+      return import('@faker-js/faker/locale/en_CA');
     case 'en_GB':
-      return import('faker/locale/en_GB');
+      return import('@faker-js/faker/locale/en_GB');
     case 'en_IE':
-      return import('faker/locale/en_IE');
+      return import('@faker-js/faker/locale/en_IE');
     case 'en_IND':
-      return import('faker/locale/en_IND');
+      return import('@faker-js/faker/locale/en_IND');
     case 'en_US':
-      return import('faker/locale/en_US');
+      return import('@faker-js/faker/locale/en_US');
     case 'en_ZA':
-      return import('faker/locale/en_ZA');
+      return import('@faker-js/faker/locale/en_ZA');
     case 'es':
-      return import('faker/locale/es');
+      return import('@faker-js/faker/locale/es');
     case 'es_MX':
-      return import('faker/locale/es_MX');
+      return import('@faker-js/faker/locale/es_MX');
     case 'fa':
-      return import('faker/locale/fa');
+      return import('@faker-js/faker/locale/fa');
     case 'fi':
-      return import('faker/locale/fi');
+      return import('@faker-js/faker/locale/fi');
     case 'fr':
-      return import('faker/locale/fr');
+      return import('@faker-js/faker/locale/fr');
     case 'fr_CA':
-      return import('faker/locale/fr_CA');
+      return import('@faker-js/faker/locale/fr_CA');
     case 'fr_CH':
-      return import('faker/locale/fr_CH');
+      return import('@faker-js/faker/locale/fr_CH');
     case 'ge':
-      return import('faker/locale/ge');
+      return import('@faker-js/faker/locale/ge');
     case 'id_ID':
-      return import('faker/locale/id_ID');
+      return import('@faker-js/faker/locale/id_ID');
     case 'it':
-      return import('faker/locale/it');
+      return import('@faker-js/faker/locale/it');
     case 'ja':
-      return import('faker/locale/ja');
+      return import('@faker-js/faker/locale/ja');
     case 'ko':
-      return import('faker/locale/ko');
+      return import('@faker-js/faker/locale/ko');
     case 'nb_NO':
-      return import('faker/locale/nb_NO');
-    case 'nep':
-      return import('faker/locale/nep');
+      return import('@faker-js/faker/locale/nb_NO');
+    case 'ne':
+      return import('@faker-js/faker/locale/ne');
     case 'nl':
-      return import('faker/locale/nl');
+      return import('@faker-js/faker/locale/nl');
     case 'nl_BE':
-      return import('faker/locale/nl_BE');
+      return import('@faker-js/faker/locale/nl_BE');
     case 'pl':
-      return import('faker/locale/pl');
+      return import('@faker-js/faker/locale/pl');
     case 'pt_BR':
-      return import('faker/locale/pt_BR');
+      return import('@faker-js/faker/locale/pt_BR');
     case 'pt_PT':
-      return import('faker/locale/pt_PT');
+      return import('@faker-js/faker/locale/pt_PT');
     case 'ro':
-      return import('faker/locale/ro');
+      return import('@faker-js/faker/locale/ro');
     case 'ru':
-      return import('faker/locale/ru');
+      return import('@faker-js/faker/locale/ru');
     case 'sk':
-      return import('faker/locale/sk');
+      return import('@faker-js/faker/locale/sk');
     case 'sv':
-      return import('faker/locale/sv');
+      return import('@faker-js/faker/locale/sv');
     case 'tr':
-      return import('faker/locale/tr');
+      return import('@faker-js/faker/locale/tr');
     case 'uk':
-      return import('faker/locale/uk');
+      return import('@faker-js/faker/locale/uk');
     case 'vi':
-      return import('faker/locale/vi');
+      return import('@faker-js/faker/locale/vi');
     case 'zh_CN':
-      return import('faker/locale/zh_CN');
+      return import('@faker-js/faker/locale/zh_CN');
     case 'zh_TW':
-      return import('faker/locale/zh_TW');
+      return import('@faker-js/faker/locale/zh_TW');
     default:
-      return import('faker/locale/en');
+      return import('@faker-js/faker/locale/en');
   }
 }


### PR DESCRIPTION
The original faker.js library has been removed
and not maintained anymore
by the author, so the community
created the community version of faker.js. 

Let's switch to the community version for better maintenance. 

Close #49