### PR TITLE
Ability to convert documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "onCommand:faker.random",
     "onCommand:faker.system",
     "onCommand:faker.time",
-    "onCommand:faker.vehicle"
+    "onCommand:faker.vehicle",
+    "onCommand:faker.fakeDocument"
   ],
   "main": "./out/src/extension",
   "contributes": {
@@ -130,6 +131,10 @@
       {
         "command": "faker.vehicle",
         "title": "Faker: Vehicle"
+      },
+      {
+        "command": "faker.fakeDocument",
+        "title": "Convert Faker variables"
       }
     ],
     "configuration": {


### PR DESCRIPTION
I wanted a way to insert lots of fake data at once. By making use of `faker.fake`, I can insert the supported faker variables and then convert a whole document at once.

Signed-off-by: Liam Barry Allan <mrliamallan@live.co.uk>